### PR TITLE
Fix Illegal group reference when mentioned user or role names contain '$'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@
 - Include missing reachability metadata for error responses.
 - Include missing exit handlers.
 
+### discord-html-transcript-core
+
+#### Fixed
+
+- Prevent `IllegalArgumentException` when parsed user or role mentions' names contain `$` by @martinsshox.
+
 ## [0.1.0-beta.3]
 
 ### discord-html-transcript-core

--- a/core/src/main/java/dev/omardiaa/transcript/core/util/MarkdownUtil.java
+++ b/core/src/main/java/dev/omardiaa/transcript/core/util/MarkdownUtil.java
@@ -12,6 +12,7 @@ import org.jspecify.annotations.NullMarked;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Pattern;
+import java.util.regex.Matcher;
 
 @NullMarked
 public final class MarkdownUtil {
@@ -129,28 +130,36 @@ public final class MarkdownUtil {
       String userId = m.group(1);
       User user = message.getMentionsMap().get(userId);
 
+      String result;
+
       if (user == null) {
-        return "<span class=\"mention\"><@%s></span>".formatted(userId);
+        result = "<span class=\"mention\"><@%s></span>".formatted(userId);
       } else {
-        return "<a href=\"https://discord.com/users/%s\" class=\"mention\">@%s</a>".formatted(
+        result = "<a href=\"https://discord.com/users/%s\" class=\"mention\">@%s</a>".formatted(
           userId, user.getGlobalName());
       }
+
+      return Matcher.quoteReplacement(result);
     });
 
     current = MENTION_ROLE.matcher(current).replaceAll(m -> {
       String roleId = m.group(1);
       Role role = guild.getRolesMap().get(roleId);
 
+      String result;
+
       if (role == null) {
-        return "<span class=\"mention\">@unknown-role</span>";
+        result = "<span class=\"mention\">@unknown-role</span>";
       } else {
         if (role.getColors().getPrimaryColor() == 0) {
-          return "<span class=\"mention\">@%s</span>".formatted(role.getName());
+          result = "<span class=\"mention\">@%s</span>".formatted(role.getName());
         } else {
-          return "<span class=\"mention\" style=\"color: #%1$06X; background-color: #%1$06X10;\" onmouseover=\"this.style.backgroundColor='#%1$06X30';\" onmouseout=\"this.style.backgroundColor='#%1$06X10';\">@%2$s</span>\n".formatted(
+          result = "<span class=\"mention\" style=\"color: #%1$06X; background-color: #%1$06X10;\" onmouseover=\"this.style.backgroundColor='#%1$06X30';\" onmouseout=\"this.style.backgroundColor='#%1$06X10';\">@%2$s</span>\n".formatted(
             role.getColors().getPrimaryColor(), role.getName());
         }
       }
+
+      return Matcher.quoteReplacement(result);
     });
 
     current = MENTION_CHANNEL.matcher(current).replaceAll(m -> {

--- a/core/src/main/java/dev/omardiaa/transcript/core/util/MarkdownUtil.java
+++ b/core/src/main/java/dev/omardiaa/transcript/core/util/MarkdownUtil.java
@@ -11,8 +11,9 @@ import org.jspecify.annotations.NullMarked;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.regex.Pattern;
+import java.util.regex.MatchResult;
 import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 @NullMarked
 public final class MarkdownUtil {
@@ -126,60 +127,57 @@ public final class MarkdownUtil {
   public static String parseMarkup(Guild guild, Message message, String content) {
     String current = parseMarkup(content);
 
-    current = MENTION_USER.matcher(current).replaceAll(m -> {
-      String userId = m.group(1);
-      User user = message.getMentionsMap().get(userId);
+    current = MENTION_USER.matcher(current).replaceAll(m -> parseMarkupUserMention(m, message));
+    current = MENTION_ROLE.matcher(current).replaceAll(m -> parseMarkupRoleMention(m, guild));
 
-      String result;
+    // parses to "unknown" since there's no reliable way to retrieve a guild's channels' names.
+    current = MENTION_CHANNEL.matcher(current).replaceAll(
+      m -> "<span class=\"mention\">%s<em>unknown</em></span>\n".formatted(SVG_CHANNEL_ICON));
 
-      if (user == null) {
-        result = "<span class=\"mention\"><@%s></span>".formatted(userId);
-      } else {
-        result = "<a href=\"https://discord.com/users/%s\" class=\"mention\">@%s</a>".formatted(
-          userId, user.getGlobalName());
-      }
-
-      return Matcher.quoteReplacement(result);
-    });
-
-    current = MENTION_ROLE.matcher(current).replaceAll(m -> {
-      String roleId = m.group(1);
-      Role role = guild.getRolesMap().get(roleId);
-
-      String result;
-
-      if (role == null) {
-        result = "<span class=\"mention\">@unknown-role</span>";
-      } else {
-        if (role.getColors().getPrimaryColor() == 0) {
-          result = "<span class=\"mention\">@%s</span>".formatted(role.getName());
-        } else {
-          result = "<span class=\"mention\" style=\"color: #%1$06X; background-color: #%1$06X10;\" onmouseover=\"this.style.backgroundColor='#%1$06X30';\" onmouseout=\"this.style.backgroundColor='#%1$06X10';\">@%2$s</span>\n".formatted(
-            role.getColors().getPrimaryColor(), role.getName());
-        }
-      }
-
-      return Matcher.quoteReplacement(result);
-    });
-
-    current = MENTION_CHANNEL.matcher(current).replaceAll(m -> {
-      return "<span class=\"mention\">%s<em>unknown</em></span>\n".formatted(SVG_CHANNEL_ICON);
-      /* if (channel == null) {
-         return "<span class=\"mention\">%s<em>unknown</em></span>\n".formatted(SVG_CHANNEL_ICON);
-       } else {
-         return "<a href=\"https:discord.com/channels/%s/%s\" class=\"mention\">%s<span class=\"mention__channel-name\">%s</span></a>\n".formatted(
-           guild.getId(), channelId, SVG_CHANNEL_ICON, channel.getName());
-       }*/
-    });
-
-    current = CUSTOM_EMOJI.matcher(current).replaceAll(m -> {
-      String emojiName = m.group(1);
-      String emojiUrl = Emoji.Custom.CUSTOM_EMOJI.formatted(m.group(2));
-
-      return "<img src=\"%1$s\" alt=\"%2$s\" title=\"%2$s\" class=\"markup\"/>".formatted(emojiUrl, emojiName);
-    });
+    current = CUSTOM_EMOJI.matcher(current).replaceAll(
+      m -> "<img src=\"%2$s\" alt=\"%1$s\" title=\"%1$s\" class=\"markup\">"
+        .formatted(m.group(1), Emoji.Custom.CUSTOM_EMOJI.formatted(m.group(2))));
 
     return current;
+  }
+
+  private static String parseMarkupUserMention(MatchResult m, Message message) {
+    String userId = m.group(1);
+    User user = message.getMentionsMap().get(userId);
+
+    String result;
+
+    if (user == null) {
+      result = "<span class=\"mention\"><@%s></span>".formatted(userId);
+    } else {
+      result = "<a href=\"https://discord.com/users/%s\" class=\"mention\">@%s</a>"
+        .formatted(userId, user.getGlobalName());
+    }
+
+    return Matcher.quoteReplacement(result);
+  }
+
+  private static String parseMarkupRoleMention(MatchResult m, Guild guild) {
+    String roleId = m.group(1);
+    Role role = guild.getRolesMap().get(roleId);
+
+    if (role == null) {
+      return "<span class=\"mention\">@unknown-role</span>";
+    }
+
+    String result;
+    int primaryColor = role.getColors().getPrimaryColor();
+
+    if (primaryColor == 0) {
+      result = "<span class=\"mention\">@%s</span>".formatted(role.getName());
+    } else {
+      String hexColor = Integer.toHexString(primaryColor);
+      result =
+        "<span class=\"mention\" style=\"color: #%1$s; background-color: #%1$s10;\" onmouseover=\"this.style.backgroundColor='#%1$s30';\" onmouseout=\"this.style.backgroundColor='#%1$s10';\">@%2$s</span>"
+          .formatted(hexColor, role.getName());
+    }
+
+    return Matcher.quoteReplacement(result);
   }
 
   private static String escape(String input) {

--- a/examples/payload.json
+++ b/examples/payload.json
@@ -3,7 +3,15 @@
     "id": "1055244032105787472",
     "name": "VORTEX",
     "icon": "3c970034e345f0f833b0d010f10a3be7",
-    "roles": []
+    "roles": [
+      {
+        "id": "1468338544916299968",
+        "name": "Developer",
+        "colors": {
+          "primary_color": 8729843
+        }
+      }
+    ]
   },
   "channel": {
     "id": "1444536048557494373",
@@ -63,7 +71,7 @@
               "components": [
                 {
                   "type": 10,
-                  "content": "### 🌍 Hello World!\nHello @everyone! I'm <@974748803305455627>, I created this library to transcribe <#1360350099083100353>. My current time is <t:1893456000>.\n\n### ☕ I Love Coding!\n`System.out.println(\"discord-html-transcript\");`\n```\npublic class Main {\n  public static void main(String args[]) {\n    System.out.println(\"Hello World!\");\n   }\n}\n```"
+                  "content": "### 🌍 Hello World!\nHello <@&1468338544916299968>s! I'm <@974748803305455627>, I created this library to transcribe <#1360350099083100353>. My current time is <t:1893456000>.\n\n### ☕ I Love Coding!\n`System.out.println(\"discord-html-transcript\");`\n```\npublic class Main {\n  public static void main(String args[]) {\n    System.out.println(\"Hello World!\");\n   }\n}\n```"
                 }
               ],
               "accessory": {


### PR DESCRIPTION
## Problem

`Matcher.replaceAll` interprets `$` characters in the replacement string as
regex group references.

User global names and role names in Discord may legally contain `$`.
When such a name appears in a mention replacement, Java throws:

IllegalArgumentException: Illegal group reference

This causes transcript rendering to fail during markup parsing.

## Example

User Mentioned:

id = 123
global_name = "User $"

Message Content:

Hello, <@123>

This produces the runtime exception:

IllegalArgumentException: Illegal group reference

## Fix

Wrap replacement strings with `Matcher.quoteReplacement(...)` to ensure
they are treated as literal text.

The fix was applied to:

- `MENTION_USER`
- `MENTION_ROLE`

These are the only replacements that include user-controlled values.

## Impact

Prevents transcript rendering crashes when Discord users or roles contain
special regex replacement characters such as `$` or `\`.

No behavior changes otherwise.